### PR TITLE
relax ruby version requirement

### DIFF
--- a/nbt_utils.gemspec
+++ b/nbt_utils.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bindata", "~> 1.3"
   s.add_development_dependency "bundler", ">= 1.0.0"
 
-  s.required_ruby_version = "~> 1.9"
+  s.required_ruby_version = ">= 1.9"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact


### PR DESCRIPTION
Seems to work locally with ruby 2.2.0 (OS X 10.10.2, RVM)